### PR TITLE
Fix #14 and add tree collision volume scaling with repeated collisions

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/entities/animation/AnimationHandlerFallover.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/entities/animation/AnimationHandlerFallover.java
@@ -34,8 +34,6 @@ import java.util.stream.Collectors;
 
 public class AnimationHandlerFallover implements IAnimationHandler {
 
-	boolean fallSound = false;
-
 	@Override
 	public String getName() {
 		return "fallover";
@@ -110,14 +108,12 @@ public class AnimationHandlerFallover implements IAnimationHandler {
 		}
 
 		if (fallSpeed > 0 && testCollision(entity)) {
+			float fallSpeedPrev = fallSpeed;
 			addRotation(entity, -fallSpeed);//pull back to before the collision
 			getData(entity).bounces++;
 			fallSpeed *= -AnimationConstants.TREE_ELASTICITY;//bounce with elasticity
 			entity.landed = Math.abs(fallSpeed) < 0.02f;//The entity has landed if after a bounce it has little velocity
-			if (!fallSound) {
-				entity.world.playSound(null, entity.getPosition(), ModSoundEvents.TREE_LANDING, SoundCategory.AMBIENT, 0.8F, entity.world.rand.nextFloat());
-				fallSound = true;
-			}
+			if(fallSpeedPrev > 0.1F && !entity.world.isRemote) entity.world.playSound(null, entity.getPosition(), ModSoundEvents.TREE_LANDING, SoundCategory.AMBIENT, (Math.min(1.5F, fallSpeedPrev) / 1.5F) * 0.6F + 0.1F, entity.world.rand.nextFloat() * 0.2F + 0.6F);
 		}
 
 		//Crush living things with clumsy dead trees


### PR DESCRIPTION
This fixes issue #14 by removing fallSound and instead allowing multiple tree collision sounds to play.

In order to prevent multiple collisions from repeatedly spamming the same sound, a minimum speed is required, as well as the volume scaled based on speed and the pitch randomized.

A minimum speed of 0.1 is enforced to prevent tiny bounces from playing sounds.
The volume over this minimum speed scales from 0.14 to 0.7 at a speed of 1.5 (The highest speed I recorded at time of collision averaged around 1.7.)
The pitch is randomized between 0.6 and 0.8 for added variety.

These values are semi-arbitrary ranges I came to after a little bit of testing with what I felt sounded correct, however I recommend testing them yourself and modifying them if you do not feel they fully fit.